### PR TITLE
Cleaned up logger API so call location is printed in log.

### DIFF
--- a/src/snorri/animations/Animation.java
+++ b/src/snorri/animations/Animation.java
@@ -10,6 +10,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.logging.Level;
 
 import javax.imageio.ImageIO;
 
@@ -93,12 +94,12 @@ public class Animation implements Serializable {
 			try {
 				tempFrames.add(ImageIO.read(frames[i]));
 			} catch (IOException e) {
-				Debug.error("animation frame " + frames[i].getName() + " could not be loaded", e);
+				Debug.logger.log(Level.SEVERE, "Animation frame " + frames[i].getName() + " could not be loaded.", e);
 			}
 		}
 
 		if (tempFrames.size() == 0) {
-			Debug.warning("animation " + folder.getName() + " has zero frames");
+			Debug.logger.warning("Animation " + folder.getName() + " has zero frames.");
 		}
 		
 		this.frames = new BufferedImage[tempFrames.size()];
@@ -138,12 +139,12 @@ public class Animation implements Serializable {
 				
 		String read = (String) in.readObject();
 		
-		if (read.equals("...")) { //signifies "nowhere"
+		if (read.equals("...")) { // Signifies nowhere.
 			BufferedImage im = ImageIO.read(in);
 			if (im != null) {
 				set(new Animation(im));
 			} else {
-				Debug.warning("could not load custom frame in animation");
+				Debug.logger.warning("Could not load custom frame in animation.");
 			}
 			return;
 		}

--- a/src/snorri/audio/Audio.java
+++ b/src/snorri/audio/Audio.java
@@ -2,6 +2,7 @@ package snorri.audio;
 
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
+import java.util.logging.Level;
 
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
@@ -40,7 +41,7 @@ public class Audio {
 			clip.open(AudioSystem.getAudioInputStream(new BufferedInputStream(new FileInputStream(Main.getFile(path)))));
 			return clip;
 		} catch (Exception e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Exception creating audio clip.", e);
 			return null;
 		}
 		
@@ -59,7 +60,6 @@ public class Audio {
 			@Override
 			public void run() {
 				try {
-					
 					AudioListener listener = new AudioListener();
 					clip.setFramePosition(0);
 					clip.start();
@@ -68,7 +68,7 @@ public class Audio {
 					clip.stop();
 					clip.setFramePosition(0);
 				} catch (Exception e) {
-					Debug.error(e);
+					Debug.logger.log(Level.SEVERE, "Failed to play audio clip.", e);
 				}
 			}
 		}).start();

--- a/src/snorri/dialog/Portraits.java
+++ b/src/snorri/dialog/Portraits.java
@@ -21,7 +21,7 @@ public class Portraits {
 	}
 	
 	public static void load() {
-		Debug.log(portraits.entrySet().size() + " portraits loaded");
+		Debug.logger.info(portraits.entrySet().size() + " portraits loaded.");
 	}
 	
 	public static Image get(String name) {

--- a/src/snorri/entities/Entity.java
+++ b/src/snorri/entities/Entity.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.logging.Level;
 
 import snorri.animations.Animation;
 import snorri.collisions.CircleCollider;
@@ -105,7 +106,7 @@ public class Entity implements Nominal, Serializable, Comparable<Entity>, Clonea
 	public Entity(Vector pos, Collider collider) {
 		this.pos = (pos == null) ? null : pos.copy();
 		if (collider == null) {
-			Debug.warning("spawning entity with null collider: " + this);
+			Debug.logger.warning("Entity " + this + " has null collider.");
 		} else {
 			this.collider = collider.cloneOnto(this);
 		}
@@ -218,7 +219,7 @@ public class Entity implements Nominal, Serializable, Comparable<Entity>, Clonea
 		for (int i = 0; i < depth; i++) {
 			indent += "  ";
 		}
-		Debug.log(indent + toString());
+		Debug.logger.info(indent + toString());
 	}
 	
 	public void traverse() {
@@ -397,7 +398,7 @@ public class Entity implements Nominal, Serializable, Comparable<Entity>, Clonea
 			newEnt.animation = new Animation(animation);
 			return newEnt;
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | SecurityException | InvocationTargetException | NoSuchMethodException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Could not copy Entity.", e);
 			return null;
 		}
 	}

--- a/src/snorri/entities/Projectile.java
+++ b/src/snorri/entities/Projectile.java
@@ -62,7 +62,7 @@ public class Projectile extends Detector implements Walker {
 			
 			Object output = weapon.useSpellOn(world, ((Caster) root), this, deltaTime / getLifeSpan());
 			if (Debug.weaponOutputLogged()) {
-				Debug.log("weapon output: " + output);
+				Debug.logger.info("Weapon output: " + output + ".");
 			}
 			
 			//we can't unify this with the above if clause because it matters when spells are applied
@@ -101,7 +101,7 @@ public class Projectile extends Detector implements Walker {
 		if (root instanceof Caster && orb != null) {
 			Object output = orb.useSpellOn(world, (Caster) root, this);
 			if (Debug.orbOutputLogged()) {
-				Debug.log("orb output: " + output);
+				Debug.logger.info("Orb output: " + output + ".");
 			}
 		}		
 	}

--- a/src/snorri/entities/QuadTree.java
+++ b/src/snorri/entities/QuadTree.java
@@ -9,7 +9,6 @@ import java.util.PriorityQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import snorri.collisions.RectCollider;
-import snorri.main.Debug;
 import snorri.main.FocusedWindow;
 import snorri.world.EntityGroup;
 import snorri.world.Executable;
@@ -356,7 +355,7 @@ public class QuadTree extends Entity implements EntityGroup {
 
 	@Override
 	public void traverse() {
-		Debug.log("traverse not yet implemented for QuadTree");
+		throw new UnsupportedOperationException("Traverse not yet implemented for QuadTree.");
 	}
 
 	@Override

--- a/src/snorri/entities/Unit.java
+++ b/src/snorri/entities/Unit.java
@@ -89,7 +89,7 @@ public abstract class Unit extends Entity implements Walker {
 		if (isDead()) {
 			world.delete(this);
 			if (Debug.deathsLogged()) {
-				Debug.log(tag + " died");
+				Debug.logger.info(tag + " died.");
 			}
 			TriggerType.KILL.activate(tag);
 		}
@@ -155,7 +155,7 @@ public abstract class Unit extends Entity implements Walker {
 	
 	public void damage(double d) {
 		if (Debug.damageEventsLogged()) {
-			Debug.log(this + "(" + (int) health + "/" + stats.getMaxHealth() + ") took " + d + " damage");
+			Debug.logger.info(this + "(" + (int) health + "/" + stats.getMaxHealth() + ") took " + d + " damage.");
 		}
 		health -= d;
 	}

--- a/src/snorri/hieroglyphs/Hieroglyphs.java
+++ b/src/snorri/hieroglyphs/Hieroglyphs.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 
 import javax.swing.ImageIcon;
 
@@ -39,17 +40,17 @@ public class Hieroglyphs {
 				glyphIcons.put(name, loadImage(name));
 			}
 		} else {
-			Debug.warning("could not find HTML glyph directory");
+			Debug.logger.severe("Could not find HTML glyph directory.");
 		}
 			
 	}
 	
-	public static                                                                              Set<String> getGlyphs() {
+	public static Set<String> getGlyphs() {
 		return glyphIcons.keySet();
 	}
 	
 	public static void load() {
-		Debug.log(glyphIcons.size() + " HTML glyphs loaded");
+		Debug.logger.info(glyphIcons.size() + " HTML glyphs loaded.");
 	}
 		
 	public static String transliterate(String raw) {
@@ -78,7 +79,7 @@ public class Hieroglyphs {
 		try {
 			return "<img class='hiero' src=\'" + f.toURI().toURL() + "'/>";
 		} catch (MalformedURLException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Bad URL for HTML glyph.", e);
 			return null;
 		}
 	}

--- a/src/snorri/inventory/Item.java
+++ b/src/snorri/inventory/Item.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Level;
 
 import javax.swing.ImageIcon;
 
@@ -150,15 +151,14 @@ public abstract class Item implements Droppable {
 		}
 
 		public Item getNew() {
-
-			if (c == null) { // the empty item
+			if (c == null) { // Create the empty item.
 				return null;
 			}
 
 			try {
 				return c.getConstructor(ItemType.class).newInstance(this);
 			} catch (Exception e) {
-				Debug.error(e);
+				Debug.logger.log(Level.SEVERE, "Could not create new Item", e);
 				return null;
 			}
 		}
@@ -173,7 +173,7 @@ public abstract class Item implements Droppable {
 			} catch (IllegalArgumentException e) {
 				return null;
 			} catch (IndexOutOfBoundsException e) {
-				Debug.log("invalid item number " + raw + " specified");
+				Debug.logger.info("Invalid item number " + raw + " specified");
 				return null;
 			}
 		}
@@ -303,7 +303,7 @@ public abstract class Item implements Droppable {
 			return spell.getMeaning(spellEvent);
 		} catch (Exception e) {
 			// Prevent unintended behavior of spells from crashing the game.
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Unexpected error during spell execution.", e);
 			return null;
 		}
 	}
@@ -432,7 +432,7 @@ public abstract class Item implements Droppable {
 			return copy;
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
 				| NoSuchMethodException | SecurityException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Could not copy item.", e);
 			return null;
 		}
 	}

--- a/src/snorri/inventory/RandomDrop.java
+++ b/src/snorri/inventory/RandomDrop.java
@@ -96,7 +96,7 @@ public class RandomDrop implements Droppable {
 	}
 
 	public static void load() {
-		Debug.log(Tier.values().length + " drop tiers loaded");
+		Debug.logger.info(Tier.values().length + " drop tiers loaded.");
 	}
 	
 	@Override

--- a/src/snorri/main/ClassFinder.java
+++ b/src/snorri/main/ClassFinder.java
@@ -5,6 +5,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 import snorri.entities.Entity;
 
@@ -21,7 +22,7 @@ public class ClassFinder {
 		try {
 			return new File(URLDecoder.decode(scannedDir, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Could not access resource", e);
 			return null;
 		}
 	}
@@ -30,7 +31,7 @@ public class ClassFinder {
 		File dir = getPackageFolder(scannedPackage); // allows directories with spaces
 		List<Class<? extends Entity>> classes = new ArrayList<Class<? extends Entity>>();
 		if (!dir.isDirectory()) {
-			Debug.warning("could not find class " + scannedPackage);
+			Debug.logger.warning("could not find class " + scannedPackage);
 			return null;
 		}
 		for (File file : dir.listFiles()) {

--- a/src/snorri/main/CutScene.java
+++ b/src/snorri/main/CutScene.java
@@ -39,9 +39,9 @@ public class CutScene extends GamePanel implements MouseListener {
 	}
 	
 	public void skip() {
-		Debug.log("skipping cutscene before " + nextWorld);
+		Debug.logger.info("skipping cutscene before " + nextWorld);
 		Main.launchGame(nextWorld, player);
-		Debug.log("game launched");
+		Debug.logger.info("game launched");
 	}
 
 	@Override

--- a/src/snorri/main/Debug.java
+++ b/src/snorri/main/Debug.java
@@ -14,7 +14,6 @@ public class Debug {
 	
 	private static final boolean ALL_HIEROGLYPHS_UNLOCKED = false;
 	private static final boolean RENDER_TILE_GRID = false;
-	private static final boolean LOG_FOCUS = false;
 	private static final boolean LOG_WORLD = false;
 	private static final boolean LOG_PARSES = false;
 	private static final boolean LOG_RENDER_QUEUE = false;
@@ -32,13 +31,11 @@ public class Debug {
 	private static final boolean LOG_CHANGE_WORLD_EVENTS = true;
 	private static final boolean LOG_PATHFINDING_COMPONENTS = false;
 	
-	private static final Logger logger;
+	public static final Logger logger;
 	
 	static {
-		// TODO(lambdaviking): Call logger methods directly and replace format with:
-		// "%1$tF %1$tT [%4$-7s][%2$s] %5$s %6$s%n".
 		System.setProperty("java.util.logging.SimpleFormatter.format",
-				"%1$tF %1$tT [%4$-7s] %5$s %6$s%n");
+				"%1$tF %1$tT [%4$-7s] [%2$s] %5$s %6$s%n");
 				
 		logger = Logger.getLogger("Thoth");
 		logger.setLevel(Level.ALL);
@@ -66,10 +63,6 @@ public class Debug {
 	
 	public static boolean tileGridRendered() {
 		return RENDER_TILE_GRID;
-	}
-	
-	public static boolean focusLogged() {
-		return LOG_FOCUS;
 	}
 	
 	public static boolean worldLogged() {
@@ -150,6 +143,7 @@ public class Debug {
 	 * @param o
 	 * 	the object to print
 	 */
+	@Deprecated
 	public static void raw(Object o) {
 		logger.log(Level.FINE, o == null ? null : o.toString());
 	}
@@ -159,6 +153,7 @@ public class Debug {
 	 * @param s
 	 * 	the string to print
 	 */
+	@Deprecated
 	public static void log(String s) {
 		logger.log(Level.INFO, s);
 	}
@@ -167,10 +162,12 @@ public class Debug {
 	 * Use this to print error messages to the game log.
 	 * @param s The error string to print.
 	 */
+	@Deprecated
 	public static void error(Throwable e) {
 		error(e.getMessage(), e);
 	}
 	
+	@Deprecated
 	public static void error(String msg, Throwable e) {
 		logger.log(Level.SEVERE, msg, e);
 	}
@@ -179,6 +176,7 @@ public class Debug {
 	 * Use this to print warning messages to the game log.
 	 * @param s The warning string to print.
 	 */
+	@Deprecated
 	public static void warning(String s) {
 		logger.log(Level.WARNING, s);
 	}

--- a/src/snorri/main/DialogMap.java
+++ b/src/snorri/main/DialogMap.java
@@ -1,6 +1,7 @@
 package snorri.main;
 
 import java.util.HashMap;
+import java.util.logging.Level;
 
 import javax.swing.JTextField;
 
@@ -46,7 +47,7 @@ public class DialogMap extends HashMap<String, JTextField> {
 		try {
 			return Class.forName(getText(key));
 		} catch (ClassNotFoundException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, key + " is not a class", e);
 			return null;
 		}
 	}

--- a/src/snorri/main/FocusedWindow.java
+++ b/src/snorri/main/FocusedWindow.java
@@ -10,6 +10,7 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.logging.Level;
 
 import javax.swing.SwingUtilities;
 
@@ -74,7 +75,7 @@ public abstract class FocusedWindow<F extends Entity> extends GamePanel implemen
 	public synchronized void openInventory(int i) {
 		F focus = getFocus();
 		if (!(focus instanceof Caster)) {
-			Debug.warning("tried to open inventory on non-Caster");
+			Debug.logger.warning("tried to open inventory on non-Caster");
 			return;
 		}
 		SwingUtilities.invokeLater(new Runnable() {
@@ -192,13 +193,13 @@ public abstract class FocusedWindow<F extends Entity> extends GamePanel implemen
 				try {
 					while (!stopped) {
 						if (Debug.pausesLogged() && isPaused()) {
-							Debug.log("paused");
+							Debug.logger.info("Game paused.");
 						}
 						onFrame();
 						Thread.sleep(FRAME_DELTA);
 					}
 				} catch (InterruptedException e) {
-					Debug.error(e);
+					Debug.logger.log(Level.SEVERE, "Game thread interrupted.", e);
 				}
 			}
 		});
@@ -206,7 +207,7 @@ public abstract class FocusedWindow<F extends Entity> extends GamePanel implemen
 		thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
 			@Override
 			public void uncaughtException(Thread t, Throwable e) {
-				Debug.error(e);
+				Debug.logger.log(Level.SEVERE, "Uncaught exception.", e);
 			}
 		});
 		thread.start();

--- a/src/snorri/main/GameWindow.java
+++ b/src/snorri/main/GameWindow.java
@@ -2,7 +2,6 @@ package snorri.main;
 
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.KeyboardFocusManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
@@ -138,11 +137,6 @@ public class GameWindow extends FocusedWindow<Player> {
 			xTrans += iter.next().render(this, g, xTrans);
 		}
 		
-		if (Debug.focusLogged()) {
-			Debug.log("Focused component: " + KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner());
-		}
-		
-		
 		g.dispose();
 		g1.dispose();
 		
@@ -165,7 +159,7 @@ public class GameWindow extends FocusedWindow<Player> {
 	}
 	
 	public void showMessage(Message m) {
-		Debug.log(m.toString());
+		Debug.logger.info("[UI] " + m.toString() + ".");
 		messageQ.add(m);
 	}
 	

--- a/src/snorri/main/LevelEditor.java
+++ b/src/snorri/main/LevelEditor.java
@@ -2,7 +2,6 @@ package snorri.main;
 
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.KeyboardFocusManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -409,7 +408,7 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 				}
 				centerCamera();
 			} catch (IOException e1) {
-				Debug.error(e1);
+				Debug.logger.warning("Failed to open World.");
 			}
 			break;
 		case "Open Level":
@@ -421,7 +420,7 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 				}
 				centerCamera();
 			} catch (IOException e1) {
-				Debug.error(e1);
+				Debug.logger.warning("Failed to open Level.");
 			}
 			break;
 		case "Save":
@@ -450,14 +449,14 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 			break;
 		case "Undo":
 			if (env == null || !canUndo) {
-				Debug.warning("unable to undo");
+				Debug.logger.warning("Unable to undo.");
 				return;
 			}
 			undo();
 			break;
 		case "Redo":
 			if (env == null || !canRedo) {
-				Debug.warning("unable to redo");
+				Debug.logger.warning("Unable to redo.");
 				return;
 			}
 			redo();
@@ -468,16 +467,16 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 			break;
 		case "Top":
 			if (env == null) {
-				Debug.warning("null editable object");
+				Debug.logger.warning("Null editable object.");
 				return;
 			}
 			w2 = connectionDialog();
 			if (w2 == null || w2 == "") {
-				Debug.warning("invalid connecting world");
+				Debug.logger.warning("Invalid connecting world.");
 				return;
 			}
 			if (env.getWorldGraph() == null) {
-				Debug.warning("could not get world graph");
+				Debug.logger.warning("Could not get world graph.");
 				return;
 			}
 			env.getWorldGraph().createLink(w2, 3);
@@ -537,7 +536,6 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 
 	@Override
 	public void paintComponent(Graphics gr) {
-
 		super.paintComponent(gr);
 		if (env == null) {
 			return;
@@ -549,11 +547,6 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 		
 		env.render(this, (Graphics2D) gr, deltaTime, false);
 		renderMousePos(gr);
-		
-		if (Debug.focusLogged()) {
-			Debug.log("Focused component: " + KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner());
-		}
-
 	}
 
 	private void renderMousePos(Graphics gr) {
@@ -639,7 +632,7 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 									}
 								}
 							
-								Debug.log("Added Tile (" + xGrid + ", " + yGrid + ") to wall");
+								Debug.logger.info("Added Tile (" + xGrid + ", " + yGrid + ") to wall.");
 								wallPoints.add(new Vector(xGrid,yGrid));
 								
 								if (wallPoints.firstElement().equals(wallPoints.lastElement())) {
@@ -648,12 +641,12 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 								}
 							}
 							else {
-								Debug.warning("Cannot add Tile (" + xGrid + ", " + yGrid + ") to wall, in wall mode, tiles must be properly spaced and normal to each other");
+								Debug.logger.warning("Cannot add Tile (" + xGrid + ", " + yGrid + ") to wall, in wall mode, tiles must be properly spaced and normal to each other.");
 							}
 						}
 						else {
 							env.getLevel(selectedTile.getType().getLayer()).setTileGrid(xGrid, yGrid, new Tile(selectedTile));
-							Debug.log("Added Tile (" + xGrid + ", " + yGrid + ") to wall");
+							Debug.logger.info("Added Tile (" + xGrid + ", " + yGrid + ") to wall.");
 							wallPoints.add(new Vector(xGrid,yGrid));
 						}
 					}
@@ -1550,7 +1543,7 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 	private void spawnEntity() {
 
 		if (!(env instanceof World)) {
-			Debug.warning("tried to spawn entity in non-world");
+			Debug.logger.warning("Tried to spawn entity in non-world.");
 			return;
 		}
 		World world = (World) env;
@@ -1616,14 +1609,14 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 				| SecurityException e) {
 			e.printStackTrace();
 		} catch (NoSuchMethodException e) {
-			Debug.warning("cannot spawn entity type " + selectedEntityClass.getSimpleName());
+			Debug.logger.warning("Cannot spawn entity type " + selectedEntityClass.getSimpleName() + ".");
 		}
 	}
 
 	private void deleteEntity() {
 
 		if (!(env instanceof World)) {
-			Debug.warning("tried to delete entity in non-world");
+			Debug.logger.warning("Tried to delete entity in non-world.");
 			return;
 		}
 		World world = (World) env;
@@ -1647,7 +1640,7 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 			canUndo = true;
 			canRedo = false;
 		} catch (IOException e) {
-			Debug.error(e);
+			Debug.logger.warning("Failed to undo.");
 		}
 	}
 
@@ -1657,8 +1650,7 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 			canUndo = false;
 			canRedo = true;
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			Debug.error(e);
+			Debug.logger.warning("Failed to redo.");
 			canRedo = false;
 		}
 	}
@@ -1670,13 +1662,12 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 				env.load(Main.getFile("/saves/.undo1"));
 				canUndo = false;
 				canRedo = true;
-				Debug.log("undone!");
+				Debug.logger.info("Undone!");
 			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				Debug.error(e);
+				Debug.logger.warning("Failed to undo.");
 			}
 		} else {
-			Debug.warning("cannot undo right now");
+			Debug.logger.info("Cannot undo right now.");
 		}
 	}
 
@@ -1684,14 +1675,14 @@ public class LevelEditor extends FocusedWindow<Entity> implements ActionListener
 		if (canRedo) {
 			try {
 				env.load(Main.getFile("/saves/.redo1"));
-				Debug.log("redo!");
+				Debug.logger.info("Redone!");
 				canUndo = true;
 				canRedo = false;
 			} catch (IOException e) {
-				Debug.error(e);
+				Debug.logger.warning("Failed to redo.");
 			}
 		} else {
-			Debug.warning("cannot redo right now");
+			Debug.logger.info("Cannot redo right now.");
 		}
 	}
 

--- a/src/snorri/main/Main.java
+++ b/src/snorri/main/Main.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.logging.Level;
 
 import javax.imageio.ImageIO;
 import javax.swing.JComponent;
@@ -33,6 +34,11 @@ import snorri.world.Vector;
 
 public class Main {
 	
+	public static final BufferedImage DEFAULT_TEXTURE = getImage("/textures/tiles/default00.png");
+	public static final String FONT_NAME = "/fonts/avenir.otf";
+	public static final int DEFAULT_WIDTH = 1280;
+	public static final int DEFAULT_HEIGHT = 720;
+	
 	private static GamePanel window;
 	private static GamePanel outerOverlay;
 
@@ -40,10 +46,6 @@ public class Main {
 	private static JLayeredPane pane;
 
 	private static Font customFont;
-	
-	public static final BufferedImage DEFAULT_TEXTURE = getImage("/textures/tiles/default00.png");
-	public static final int DEFAULT_WIDTH = 1280;
-	public static final int DEFAULT_HEIGHT = 720;
 
 	public static class ResizeListener implements ComponentListener {
 
@@ -131,10 +133,11 @@ public class Main {
 	}
 
 	public static void setupFont() {
-		customFont = loadFont("/fonts/avenir.otf");		
+		// TODO(lambdaviking): Could put this in static initializer.
+		customFont = loadFont(FONT_NAME);		
 		UIManager.put("Button.font", getCustomFont(20));
 		UIManager.put("Label.font", getCustomFont(13));
-		Debug.log("default font loaded");
+		Debug.logger.info("Default font " + FONT_NAME + " loaded.");
 	}
 
 	public static Font getCustomFont(float size) {
@@ -149,7 +152,7 @@ public class Main {
 			ge.registerFont(f);
 			return f;
 		} catch (IOException | FontFormatException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Could not find font " + path + ".", e);
 			return null;
 		}
 	}
@@ -157,11 +160,8 @@ public class Main {
 	public static BufferedImage getImage(File file) {
 		try {
 			return ImageIO.read(file);
-		} catch (IllegalArgumentException e) {
-			Debug.error(e);
-			return null;
-		} catch (IOException e) {
-			Debug.error(e);
+		} catch (IllegalArgumentException | IOException e) {
+			Debug.logger.log(Level.SEVERE, "Failed to load image " + file.getPath() + ".", e);
 			return null;
 		}
 	}
@@ -284,7 +284,7 @@ public class Main {
 					world = Playable.getLoaded(path, p);
 					setWindow(new GameWindow(world));
 				} catch (IOException | YamlException e) {
-					Debug.error(e);
+					Debug.logger.log(Level.SEVERE, "Failed to launch world at " + path.getPath() + ".", e);
 				}
 			}
 		});

--- a/src/snorri/masking/AlphaMask.java
+++ b/src/snorri/masking/AlphaMask.java
@@ -47,7 +47,7 @@ public class AlphaMask {
 		
 		assert MASKS.length == 16;
 		assert CORNER_MASKS.length == 16;
-		Debug.log("alpha masks initialized");
+		Debug.logger.info("Alpha masks initialized.");
 	}
 
 	private final Area mask;

--- a/src/snorri/nonterminals/NonTerminal.java
+++ b/src/snorri/nonterminals/NonTerminal.java
@@ -2,6 +2,7 @@ package snorri.nonterminals;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 import snorri.events.SpellEvent;
 import snorri.main.Debug;
@@ -87,7 +88,7 @@ public abstract class NonTerminal<S> implements Node<S> {
 			copy.setChildren(newChildren);
 			return copy;
 		} catch (InstantiationException | IllegalAccessException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Failed to copy NonTerminal.", e);
 			return null;
 		}
 

--- a/src/snorri/overlay/HelpOverlay.java
+++ b/src/snorri/overlay/HelpOverlay.java
@@ -2,6 +2,7 @@ package snorri.overlay;
 
 import java.awt.GridBagLayout;
 import java.io.IOException;
+import java.util.logging.Level;
 
 import snorri.main.Debug;
 import snorri.main.FocusedWindow;
@@ -21,7 +22,7 @@ public class HelpOverlay extends Overlay {
 		try {
 			display.setPage(Main.getFile("/info/index.html").toURI().toURL());
 		} catch (IOException e) {
-			Debug.error(e);
+			Debug.logger.log(Level.SEVERE, "Could not load help page.", e);
 		}
 		add(display);
 		

--- a/src/snorri/overlay/Overlay.java
+++ b/src/snorri/overlay/Overlay.java
@@ -13,6 +13,7 @@ import java.awt.event.KeyListener;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.logging.Level;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -223,7 +224,7 @@ public abstract class Overlay extends GamePanel implements KeyListener {
 			s.importStyleSheet(Main.getFile("/info/style.css").toURI().toURL());
 			kit.setStyleSheet(s);
 		} catch (MalformedURLException e) {
-			Debug.log("could not load stylesheet");
+			Debug.logger.log(Level.SEVERE, "Could not load stylesheet.", e);
 		}
 		return kit;
 	}

--- a/src/snorri/parser/Grammar.java
+++ b/src/snorri/parser/Grammar.java
@@ -76,7 +76,7 @@ public class Grammar extends HashMap<Class<? extends NonTerminal<?>>, List<Rule>
 		grammar.add(new Rule(new Object[] {Sentence.class, AdverbPhrase.class}, Sentence.class));
 		
 		List<Rule> allRules = grammar.get();
-		Debug.log("CFG with " + allRules.size() + " high-level rules loaded");
+		Debug.logger.info("CFG with " + allRules.size() + " high-level rules loaded.");
 		maxLength = 0;
 		for (Rule rule : allRules) {
 			maxLength = Integer.max(maxLength, rule.getLength());
@@ -130,7 +130,7 @@ public class Grammar extends HashMap<Class<? extends NonTerminal<?>>, List<Rule>
 			}
 			List<Node<?>> parses = topDown(getNodes(input), Sentence.class);
 			if (Debug.parsesLogged()) {
-				Debug.log("parses for " + input + ": " + parses);
+				Debug.logger.info("Parses for " + input + ": " + parses + ".");
 			}
 			return parses;
 		} catch (InstantiationException | IllegalAccessException e) {
@@ -184,7 +184,7 @@ public class Grammar extends HashMap<Class<? extends NonTerminal<?>>, List<Rule>
 				for (List<Node<?>> nodes : Util.computeCombinations(allPoss)) {
 					Class<? extends NonTerminal<?>> c = rewrite.fits(nodes);
 					if (c == null) {
-						Debug.warning("very weird parsing issue");
+						Debug.logger.warning("Very unexpected parsing issue.");
 						return null;
 					}
 					NonTerminal<?> node = c.newInstance();

--- a/src/snorri/pathfinding/PathGraph.java
+++ b/src/snorri/pathfinding/PathGraph.java
@@ -236,7 +236,6 @@ public class PathGraph {
 	}
 	
 	private void computeComponents() {
-
 		components = new HashSet<>();
 		boolean[][] visited = new boolean[getWidth()][getHeight()];
 		
@@ -253,11 +252,10 @@ public class PathGraph {
 		}
 
 		if (Debug.pathfindingComponentsLogged()) {
-			Debug.log("found " + components.size() + " pathfinding components");
+			Debug.logger.info("Found " + components.size() + " pathfinding components.");
 		}
 
 		computeGraphHash();
-
 	}
 
 	@Deprecated
@@ -274,7 +272,7 @@ public class PathGraph {
 	public void loadComponents(File f) throws FileNotFoundException, IOException {
 
 		if (!f.exists()) {
-			Debug.log("graph data not found in world; computing it from scratch");
+			Debug.logger.info("Graph data not found in world; computing it from scratch.");
 			computePathfinding();
 			return;
 		}
@@ -284,8 +282,7 @@ public class PathGraph {
 			components = (Set<Component>) in.readObject();
 			computeGraphHash();
 		} catch (ClassNotFoundException e) {
-			Debug.error(e);
-			Debug.log("recalculating corrupted pathfinding data");
+			Debug.logger.log(java.util.logging.Level.WARNING, "Recalculating corrupted pathfinding data.", e);
 			computeComponents();
 		}
 		in.close();

--- a/src/snorri/pathfinding/Pathfinding.java
+++ b/src/snorri/pathfinding/Pathfinding.java
@@ -36,7 +36,7 @@ public class Pathfinding {
 	
 	public PathGraph getGraph(Pathfinder p) {
 		if (getGraph(p.getGridBounds()) == null) {
-			Debug.warning("missing pathfinding graph for " + p);
+			Debug.logger.warning("Missing pathfinding graph for " + p + ".");
 			return getDefaultGraph();
 		}
 		return getGraph(p.getGridBounds());

--- a/src/snorri/pathfinding/Team.java
+++ b/src/snorri/pathfinding/Team.java
@@ -9,6 +9,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 import snorri.entities.Unit;
 import snorri.main.Debug;
@@ -31,13 +32,13 @@ public class Team extends ArrayList<Unit> {
 			ObjectInputStream stream = new ObjectInputStream(new FileInputStream(teamsFile));
 			List<Team> teams = (List<Team>) stream.readObject();
 			if (teams == null) {
-				Debug.log("loaded null list of teams");
+				Debug.logger.info("Loaded null list of teams.");
 			} else {
-				Debug.log("loaded " + teams.size() + " teams");
+				Debug.logger.info("Loaded " + teams.size() + " teams.");
 			}
 			return teams;
 		} catch (ClassNotFoundException e) {
-			Debug.error("corrupted team data", e);
+			Debug.logger.log(Level.SEVERE, "Team data is corrupted.", e);
 			return null;
 		}
 	}
@@ -47,7 +48,7 @@ public class Team extends ArrayList<Unit> {
 		ObjectOutputStream stream = new ObjectOutputStream(new FileOutputStream(teamsFile));
 		stream.writeObject(teams);
 		if (teams != null) {
-			Debug.log("saved " + teams.size() + " teams");
+			Debug.logger.info("Saved " + teams.size() + " teams.");
 		}
 	}
 	

--- a/src/snorri/semantics/Grow.java
+++ b/src/snorri/semantics/Grow.java
@@ -1,6 +1,7 @@
 package snorri.semantics;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Level;
 
 import snorri.entities.Entity;
 import snorri.entities.Plant;
@@ -16,8 +17,7 @@ public class Grow extends TransVerbDef {
 	}
 
 	@Override @SuppressWarnings("unchecked")
-	public boolean exec(Node<Object> object, SpellEvent e) {
-		
+	public boolean exec(Node<Object> object, SpellEvent e) {	
 		Object meaning = object.getMeaning(e);
 		if (!(meaning instanceof ClassWrapper)) {
 			return false;
@@ -31,12 +31,11 @@ public class Grow extends TransVerbDef {
 				return true;
 			} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
 					| NoSuchMethodException | SecurityException e2) {
-				Debug.error(e2);
+				Debug.logger.log(Level.WARNING, "Unexpected failure in Grow.", e2);
 			}
 		}
 		
 		return false;
-		
 	}
 
 	@Override

--- a/src/snorri/triggers/Action.java
+++ b/src/snorri/triggers/Action.java
@@ -98,7 +98,7 @@ public abstract class Action {
 						if (window instanceof GameWindow) {
 							((GameWindow) window).setObjective((Objective) args.get("objective"));
 						} else {
-							Debug.warning("setting objective in non-GameWindow");
+							Debug.logger.warning("Tried to set objective in non-GameWindow.");
 						}
 					}
 				};
@@ -113,7 +113,7 @@ public abstract class Action {
 					public void run() {
 						final Class<? extends Entity> type = Entity.getSpawnableByName((String) args.get("type"));
 						if (type == null) {
-							Debug.warning("tried to spawn null entity type in trigger action");
+							Debug.logger.warning("Tried to spawn null entity type in trigger action.");
 							return;
 						}
 						Entity e = Entity.spawnNew(world, (Vector) args.get("pos"), type);

--- a/src/snorri/triggers/Trigger.java
+++ b/src/snorri/triggers/Trigger.java
@@ -87,7 +87,7 @@ public class Trigger {
 				Entry<String, Map<String, Object>> e = getFirstEntry(event);
 				TriggerType type = TriggerType.valueOf(e.getKey());
 				if (type == null) {
-					Debug.warning("unknown event type " + e.getKey());
+					Debug.logger.warning("Unknown event type " + e.getKey() + ".");
 					return;
 				}
 				if (type == TriggerType.BROADCAST) {
@@ -117,7 +117,7 @@ public class Trigger {
 			new Trigger(world, name, data, triggers);
 		}
 		
-		Debug.log(rawTriggers.size() + " triggers loaded");
+		Debug.logger.info(rawTriggers.size() + " triggers loaded.");
 			
 		triggers.setLoaded();
 		
@@ -149,7 +149,7 @@ public class Trigger {
 	 * Execute the action queue
 	 */
 	public void exec() {
-		Debug.log("firing trigger " + name + "...");
+		Debug.logger.info("Firing trigger " + name + "...");
 		while (!runnableActions.isEmpty()) { //TODO are there still bugs with runnables?
 			new Thread(runnableActions.poll()).start();
 		}

--- a/src/snorri/world/Level.java
+++ b/src/snorri/world/Level.java
@@ -172,7 +172,7 @@ public class Level implements Editable {
 				newMap[i][j] = new Tile(BackgroundElement.SAND);
 			}
 		}
-		Debug.log("Resizing Level from\t" + getWidth() + "\tx\t" + getHeight() + "\tto\t" + newDim.getX() + "\tx\t" + newDim.getY() +"\tusing resize function");
+		Debug.logger.info("Resizing Level from\t" + getWidth() + "\tx\t" + getHeight() + "\tto\t" + newDim.getX() + "\tx\t" + newDim.getY() +"\tusing resize function.");
 		for (int i = 0; i < newDim.getX() && i < getWidth(); i++) {
 			for (int j = 0; j < newDim.getY() && j < getHeight(); j++) {
 				newMap[i][j] = map[i][j];
@@ -180,7 +180,7 @@ public class Level implements Editable {
 		}
 
 		map = newMap;
-		Debug.log("New Level Size:\t" + getWidth() + "\tx\t" + getHeight());		
+		Debug.logger.info("New Level Size:\t" + getWidth() + "\tx\t" + getHeight() + ".");		
 	}
 	
 	public Level getResized(int newWidth, int newHeight, int layer) {
@@ -282,8 +282,7 @@ public class Level implements Editable {
 	}
 
 	public void load(File file, Class<? extends TileType> c) throws FileNotFoundException, IOException {
-
-		Debug.log("loading " + file + "...");
+		Debug.logger.info("Loading " + file + "...");
 
 		byte[] b = new byte[4];
 
@@ -314,8 +313,7 @@ public class Level implements Editable {
 	}
 
 	public void save(File file, boolean saveGraphs) throws IOException {
-
-		Debug.log("saving " + file.getName() + "...");
+		Debug.logger.info("Saving " + file.getName() + "...");
 
 		FileOutputStream os = new FileOutputStream(file);
 		ByteBuffer b1 = ByteBuffer.allocate(4);

--- a/src/snorri/world/Playable.java
+++ b/src/snorri/world/Playable.java
@@ -38,7 +38,7 @@ public interface Playable extends Savable {
 		try {
 			load(folder, null);
 		} catch (YamlException e) {
-			Debug.error("couldn't parse config.yml", e);
+			Debug.logger.log(java.util.logging.Level.SEVERE, "couldn't parse config.yml", e);
 		}
 	}
 	

--- a/src/snorri/world/Savable.java
+++ b/src/snorri/world/Savable.java
@@ -27,18 +27,14 @@ public interface Savable {
 	}
 	
 	default void wrapSave() {
-		
 		File f = Main.getFileDialog("Select save destination", FileDialog.SAVE, this instanceof Level);
-		
 		if (f == null) {
 			return;
 		}
-		
 		try {
 			save(f, true);
 		} catch (IOException er) {
-			// TODO can this be caught somewhere else?
-			Debug.error("are all object serializable?", er);
+			Debug.logger.log(java.util.logging.Level.SEVERE, "Are all object serializable?", er);
 			er.printStackTrace();
 		}
 	}

--- a/src/snorri/world/Tile.java
+++ b/src/snorri/world/Tile.java
@@ -252,12 +252,12 @@ public class Tile implements Comparable<Tile>, Nominal {
 	public int compareTo(Tile t) {
 		
 		if (!type.getClass().equals(t.type.getClass())) {
-			Debug.warning("comparing TileTypes from different layers");
+			Debug.logger.warning("Comparing TileTypes from different layers.");
 			return 0;
 		}
 		
 		if (type == null || t.type == null) {
-			Debug.warning("one or more tiles are null");
+			Debug.logger.warning("One or more tiles are null.");
 			if (type == null && t.type == null) {
 				return 0;
 			}

--- a/src/snorri/world/TileType.java
+++ b/src/snorri/world/TileType.java
@@ -114,7 +114,7 @@ public interface TileType extends Nominal {
 		if (x < Tile.sounds.length)
 			return Tile.sounds[x];
 		else {
-			Debug.warning("audio clip index out of bounds");
+			Debug.logger.warning("Audio clip index out of bounds.");
 			return null;
 		}
 	}

--- a/src/snorri/world/World.java
+++ b/src/snorri/world/World.java
@@ -80,16 +80,11 @@ public class World implements Playable, Editable {
 	}
 
 	public World(File file, Player p) throws FileNotFoundException, IOException {
-
 		load(file);
-		
-		Debug.log("non-null player" + p);
 		if (p != null) {
 			spawnPlayer(p);
 		}
-
 		pathfinding = new Pathfinding(getPathfindingLevels());
-		
 	}
 		
 	public World(File file) throws FileNotFoundException, IOException {
@@ -118,16 +113,15 @@ public class World implements Playable, Editable {
 		return p;
 	}
 
+	@Deprecated
 	public Vector getRandomSpawnPos(int radius) {
 		for (int i = 0; i < RANDOM_SPAWN_ATTEMPTS; i++) {
-			Vector pos = getGoodSpawn(background.getDimensions().random()); // FIXME:
-																						// good
-																						// spawn?
+			Vector pos = getGoodSpawn(background.getDimensions().random());
 			if (pos != null && col.getFirstCollision(new Entity(pos, radius)) == null) {
 				return pos;
 			}
 		}
-		Debug.warning("could not find suitable spawn");
+		Debug.logger.warning("Could not find suitable spawn.");
 		return null;
 	}
 
@@ -143,7 +137,7 @@ public class World implements Playable, Editable {
 	public synchronized void update(Entity focus, double d) {
 
 		if (Debug.worldLogged()) {
-			Debug.log("world update");
+			Debug.logger.info("World updated.");
 		}
 
 		col.updateAround(this, d, focus);
@@ -243,7 +237,7 @@ public class World implements Playable, Editable {
 		}
 
 		if (!f.exists()) {
-			Debug.log("creating new world directory...");
+			Debug.logger.info("Creating new world directory...");
 			f.mkdir();
 		}
 		
@@ -313,11 +307,11 @@ public class World implements Playable, Editable {
 	}
 
 	public void resize(int newWidth, int newHeight) {
-		Debug.log("Resizing Level from\t((" + background.getWidth() + "," + midground.getWidth() + "," + foreground.getWidth() + ")\tx\t(" + background.getHeight() + "," + midground.getHeight() + "," + foreground.getHeight() + "))\tto\t(" + newWidth + "\tx\t" + newHeight +")\tusing constructor");
+		Debug.logger.info("Resizing Level from\t((" + background.getWidth() + "," + midground.getWidth() + "," + foreground.getWidth() + ")\tx\t(" + background.getHeight() + "," + midground.getHeight() + "," + foreground.getHeight() + "))\tto\t(" + newWidth + "\tx\t" + newHeight +")\tusing constructor.");
 		background = background.getResized(newWidth, newHeight, 0);
 		midground = midground.getResized(newWidth, newHeight, 1);
 		foreground = foreground.getResized(newWidth, newHeight, 2);
-		Debug.log("New Level Size:\t(" + background.getWidth() + "," + midground.getWidth() + "," + foreground.getWidth() + ")\tx\t(" + background.getHeight() + "," + midground.getHeight() + "," + foreground.getHeight() + "))");
+		Debug.logger.info("New Level Size:\t(" + background.getWidth() + "," + midground.getWidth() + "," + foreground.getWidth() + ")\tx\t(" + background.getHeight() + "," + midground.getHeight() + "," + foreground.getHeight() + ")).");
 	}
 
 	@Override

--- a/src/snorri/world/WorldGraph.java
+++ b/src/snorri/world/WorldGraph.java
@@ -60,7 +60,7 @@ public class WorldGraph implements Playable {
 		setCurrentWorld(worlds.get(yaml.get("root")));
 				
 		List<Map<String, String>> edges = (List<Map<String, String>>) yaml.get("edges");
-		Debug.log("loading " + edges.size() + " edges");
+		Debug.logger.info("Loading " + edges.size() + " edges.");
 		for (Map<String, String> edge : edges) {
 			String w1, w2;
 			if ((w1 = edge.get("left")) != null && (w2 = edge.get("right")) != null) {
@@ -114,35 +114,35 @@ public class WorldGraph implements Playable {
 					worlds.get(w2).setLeftNeighbor(worlds.get(w1));
 					newEdge.put("left", w1);
 					newEdge.put("right", w2);
-					Debug.log("inserting new l-r edge between " + w1 + " & " + w2);
+					Debug.logger.info("Inserting new l-r edge between " + w1 + " & " + w2 + ".");
 					break;
 				case 1:
 					worlds.get(w1).setBottomNeighbor(worlds.get(w2));
 					worlds.get(w2).setTopNeighbor(worlds.get(w1));
 					newEdge.put("top", w1);
 					newEdge.put("bottom", w2);
-					Debug.log("inserting new top-bot edge between " + w1 + " & " + w2);
+					Debug.logger.info("Inserting new top-bot edge between " + w1 + " & " + w2 + ".");
 					break;
 				case 2:
 					worlds.get(w1).setLeftNeighbor(worlds.get(w2));
 					worlds.get(w2).setRightNeighbor(worlds.get(w1));
 					newEdge.put("right", w1);
 					newEdge.put("left", w2);
-					Debug.log("inserting new r-l edge between " + w1 + " & " + w2);
+					Debug.logger.info("Inserting new r-l edge between " + w1 + " & " + w2 + ".");
 					break;
 				case 3:
 					worlds.get(w1).setTopNeighbor(worlds.get(w2));
 					worlds.get(w2).setBottomNeighbor(worlds.get(w1));
 					newEdge.put("bottom", w1);
 					newEdge.put("top", w2);
-					Debug.log("inserting new bot-top edge between " + w1 + " & " + w2);
+					Debug.logger.info("Inserting new bot-top edge between " + w1 + " & " + w2 + ".");
 					break;
 				default:
 					worlds.get(w1).setRightNeighbor(worlds.get(w2));
 					worlds.get(w2).setLeftNeighbor(worlds.get(w1));
 					newEdge.put("left", w1);
 					newEdge.put("right", w2);
-					Debug.log("inserting new l-r edge between " + w1 + " & " + w2 + " (BY DEFAULT)");
+					Debug.logger.info("Inserting new l-r edge between " + w1 + " & " + w2 + " (BY DEFAULT).");
 					break;
 			}
 			
@@ -153,14 +153,8 @@ public class WorldGraph implements Playable {
 	        writer.write(yaml);
 	        writer.close();
 		}
-		catch (YamlException e) {
-			Debug.error("invalid yaml", e);
-		}
-		catch (FileNotFoundException e) {
-			Debug.error("invalid yaml?", e);
-		}
-		catch (IOException e) {
-			Debug.error("invalid yaml??", e);
+		catch (YamlException | IOException e) {
+			Debug.logger.log(java.util.logging.Level.SEVERE, "Unable to load YAML.", e);
 		}
 	}
 	
@@ -211,11 +205,10 @@ public class WorldGraph implements Playable {
 	}
 	
 	public void crossInto(World world, Vector pos) {
-		
-		// first remove any extraneous player in new world
+		// first remove any extraneous player in new world.
 		world.delete(world.getEntityTree().getFirst(Player.class));
 		
-		// move the player into the new world
+		// move the player into the new world.
 		getCurrentWorld().delete(player);
 		setCurrentWorld(world);
 		player.setPos(pos);
@@ -224,13 +217,12 @@ public class WorldGraph implements Playable {
 		// TODO save string names for worlds
 		
 		if (Debug.changeWorldEventsLogged()) {
-			Debug.log("entered world " + world + ":");
-			Debug.log(" * right neighbor: " + world.getRightNeighbor());
-			Debug.log(" * left neighbor: " + world.getLeftNeighbor());
-			Debug.log(" * top neighbor: " + world.getTopNeighbor());
-			Debug.log(" * bottom neighbor: " + world.getBottomNeighbor());
+			Debug.logger.info("Entered world " + world + ":");
+			Debug.logger.info("\t* Right neighbor: " + world.getRightNeighbor() + ".");
+			Debug.logger.info("\t* Left neighbor: " + world.getLeftNeighbor() + ".");
+			Debug.logger.info("\t* Top neighbor: " + world.getTopNeighbor() + ".");
+			Debug.logger.info("\t* Bottom neighbor: " + world.getBottomNeighbor() + ".");
 		}
-		
 	}
 	
 	public void crossInto(World world, int x, int y) {


### PR DESCRIPTION
Changed log format so that the call location is printed. The logger field was made public.

Because of these changes, the `Debug.*` methods have been deprecated. Calling the logger methods directly ensures that the true call location is actually printed in the log.

```java
Debug.log("this is a statement"); // Old-style logging call (DEPRECATED).
Debug.logger.info("This is a statement."); // New-style logging call.
```

Here is an example of what the new log format looks like:
```
2018-08-20 02:26:29 [INFO   ] [snorri.hieroglyphs.Hieroglyphs load] 68 HTML glyphs loaded. 
2018-08-20 02:26:29 [INFO   ] [snorri.inventory.RandomDrop load] 5 drop tiers loaded. 
2018-08-20 02:26:29 [INFO   ] [snorri.dialog.Portraits load] 6 portraits loaded. 
2018-08-20 02:26:29 [INFO   ] [snorri.main.Main setupFont] Default font /fonts/avenir.otf loaded. 
```
Note that this format will display stack traces where appropriate.

Fixes #19.